### PR TITLE
docs(oikos): Updated README to reflect new on-chain data logic

### DIFF
--- a/projects/oikos/README.md
+++ b/projects/oikos/README.md
@@ -2,7 +2,7 @@
 
 This adapter calculates TVL and fees for the Oikos protocol on BNB Chain using on-chain data. Unlike the Synthetix adapter, which relies on an off-chain endpoint, Oikos requires direct blockchain queries for accurate results.
 
-Methodology
+Methodology 
 TVL Calculation:
 TVL is calculated by summing the totalSupply() of all relevant Synth contracts. Each Synth’s supply is retrieved directly from the blockchain and converted to USD values.
 


### PR DESCRIPTION
This README update reflects the improved TVL and fees calculation logic for the Oikos adapter. Since Oikos does not use an off-chain API (unlike Synthetix), this new logic relies on on-chain queries to retrieve Synth total supplies and FeePool data. This README update aligns with the improved methodology in [#3](https://github.com/RaresAestheth/DefiLlama-Adapters/pull/3).
